### PR TITLE
z88dk no longer uses Z80_OZFILES environment variable.

### DIFF
--- a/z88dk/libhttp/Makefile
+++ b/z88dk/libhttp/Makefile
@@ -9,7 +9,7 @@ all:	$(COBJS)
 	$(LIBLINKER) $(LIBLDFLAGS) -x$(LIBNAME) $(COBJS)
 
 install:
-	$(CP) *.lib $(Z80_OZFILES)/clibs
-	$(CP) -r ./include $(Z80_OZFILES)/../
+	$(CP) *.lib $(ZCCCFG)/../clibs
+	$(CP) -r ./include $(ZCCCFG)/../../
 
 include ../make.inc

--- a/z88dk/libspectranet/Makefile
+++ b/z88dk/libspectranet/Makefile
@@ -30,7 +30,7 @@ basext:	$(BASOBJS)
 	
 	
 install:
-	$(CP) *.lib $(Z80_OZFILES)/clibs
-	$(CP) -r ./include $(Z80_OZFILES)/../
+	$(CP) *.lib $(ZCCCFG)/../clibs
+	$(CP) -r ./include $(ZCCCFG)/../../
 
 include ../make.inc

--- a/z88dk/socklib/Makefile
+++ b/z88dk/socklib/Makefile
@@ -30,7 +30,7 @@ nptest:	$(NPCOBJS)
 	$(CC) $(CFLAGS) -o $(NPTESTOUT) $(NPCOBJS) $(NPCLIBS)
 	
 install:
-	$(CP) *.lib $(Z80_OZFILES)/clibs
-	$(CP) -r ./include $(Z80_OZFILES)/../
+	$(CP) *.lib $(ZCCCFG)/../clibs
+	$(CP) -r ./include $(ZCCCFG)/../../
 
 include ../make.inc


### PR DESCRIPTION
Alter makefiles to work with new installations of z88dk