### PR TITLE
add a 50ms delay for each 1K block as spectranet might be not able to handle it

### DIFF
--- a/devtools/ethup.c
+++ b/devtools/ethup.c
@@ -157,6 +157,8 @@ WSADATA wsaData;
 		{
 			bytes-=sent;
 		}
+		/* spectranet is a bit too slow */
+		usleep(50000);
 	}
 	printf("\n");
 


### PR DESCRIPTION
When uploading a 4K module to fuse on windows, it gets a bit slow and gets stuck midway.
![image](https://user-images.githubusercontent.com/1666014/95684403-3131aa00-0bfa-11eb-9ecc-7ae75501e157.png)
Debugger stays its `ECONNRESET`
![image](https://user-images.githubusercontent.com/1666014/95684416-4d354b80-0bfa-11eb-9c5b-55b26b2dd607.png)
```asm
ECONNRESET	equ 0xFC	
```
Inserting a 50ms delay on sender side has solved it for me.