### PR TITLE
Port option for httplib, swap \n\r to \r\n

### DIFF
--- a/examples/twitter/tweethttp.c
+++ b/examples/twitter/tweethttp.c
@@ -43,6 +43,7 @@ int dotweet(char *user, char *passwd, char *tweet)
 
 	tweetUri.proto=PROTO_HTTP;
 	tweetUri.host=host;
+    tweetUri.port=80;
 	tweetUri.location="/1/statuses/update.json?source=twitterandroid";
 	tweetUri.user=user;
 	tweetUri.passwd=passwd;

--- a/z88dk/libhttp/include/http.h
+++ b/z88dk/libhttp/include/http.h
@@ -65,21 +65,22 @@
 #define EHTTP_TIMEOUT 	-17
 #define HDR_END		1
 
-#define USER_AGENT	"User-Agent: ZXSpectrumHTTP/1.0\n\r"
-#define ACCEPT_HDR	"Accept: */*\n\r"
+#define USER_AGENT	"User-Agent: ZXSpectrumHTTP/1.0\x0D\x0A"
+#define ACCEPT_HDR	"Accept: */*\x0D\x0A"
 #define AUTH_HDR	"Authorization: Basic "
-#define CONTENT_HDR	"Content-Type: application/x-www-form-urlencoded\n\r"
+#define CONTENT_HDR	"Content-Type: application/x-www-form-urlencoded\x0D\x0A"
 #define CONTLEN_HDR	"Content-Length"
 #define XFERENC_HDR	"Transfer-Encoding"
 #define XFER_CHUNKED	"chunked"
-#define HDR_SEP		"\n\r\n\r"
-#define LINE_END		"\n\r"
+#define HDR_SEP		"\x0D\x0A\x0D\x0A"
+#define LINE_END		"\x0D\x0A"
 #define HDR_KEYVALSEP	": "
 
 typedef struct _uri
 {
 	int proto;
 	char *host;
+	int port;
 	char *location;
 	char *user;
 	char *passwd;

--- a/z88dk/libhttp/readHeaders.c
+++ b/z88dk/libhttp/readHeaders.c
@@ -125,7 +125,7 @@ char *getHeaders(int sockfd, int *remainsz, int *result)
 	}
 
 	*hdrptr=0;
-	hdrptr+=2;	/* advance past the \n\r */
+	hdrptr+=2;	/* advance past the \r\n */
 
 	/* iterate through all the headers we have */
 	while(hdrptr=getSingleHeader(hdrptr, result))

--- a/z88dk/libhttp/request.c
+++ b/z88dk/libhttp/request.c
@@ -57,7 +57,7 @@ int request(int type, URI *uri)
 	if(sockfd < 0) return EHTTP_SOCKFAIL;
 
 	/* TODO: implement arbitrary ports for http */
-	remoteaddr.sin_port=htons(80);
+	remoteaddr.sin_port=htons(uri->port);
 	remoteaddr.sin_addr.s_addr=he->h_addr;
 	if(connect(sockfd, &remoteaddr, sizeof(struct sockaddr_in)) < 0)
 	{
@@ -67,7 +67,7 @@ int request(int type, URI *uri)
 
 	if(type == GET)
 	{
-		sprintf(hdrbuf, "GET %s HTTP/1.1\n\r", uri->location);
+		sprintf(hdrbuf, "GET %s HTTP/1.1\x0D\x0A", uri->location);
 		addStdHeaders(hdrbuf, uri, HDRBUFSZ);
 		strlcat(hdrbuf, LINE_END, HDRBUFSZ);
 		bytes=send(sockfd, hdrbuf, strlen(hdrbuf), 0);
@@ -76,7 +76,7 @@ int request(int type, URI *uri)
 	}
 	else
 	{
-		sprintf(hdrbuf, "POST %s HTTP/1.1\n\r", uri->location);
+		sprintf(hdrbuf, "POST %s HTTP/1.1\x0D\x0A", uri->location);
 		addStdHeaders(hdrbuf, uri, HDRBUFSZ);
 
 		/* make up the Content-Length header */
@@ -84,7 +84,7 @@ int request(int type, URI *uri)
 		 * function */
 		strlcat(hdrbuf, CONTLEN_HDR, HDRBUFSZ);
 		strlcat(hdrbuf, ": ", HDRBUFSZ);
-		sprintf(csizebuf, "%d\n\r", postsize());
+		sprintf(csizebuf, "%d\x0D\x0A", postsize());
 		strlcat(hdrbuf, csizebuf, HDRBUFSZ);
 
 		strlcat(hdrbuf, CONTENT_HDR, HDRBUFSZ);
@@ -101,7 +101,7 @@ int request(int type, URI *uri)
 		while(fptr)
 		{
 			/*
-			sprintf(hdrbuf, "%s=%s\n\r", 
+			sprintf(hdrbuf, "%s=%s\x0D\x0A",
 					fptr->param,
 					fptr->data);
 			printf("SENDING: %s", hdrbuf);
@@ -116,7 +116,7 @@ int request(int type, URI *uri)
 			}
 			else
 			{
-				sprintf(tmpbuf, "%s=%s\n\r",
+				sprintf(tmpbuf, "%s=%s\x0D\x0A",
 					fptr->param,
 					fptr->data);
 			}


### PR DESCRIPTION
1. Current httplib implementation lacks port option configuration.
2. HTTP GET doesn't appear to be working on any server I've tried, because it sends `\n\r` instead of `\r\n` that's needed. Tested the change on my local server, now works fine.