### PR TITLE
Changes to support "C" debugging of real spectrum

### DIFF
--- a/include/sysvars.inc
+++ b/include/sysvars.inc
@@ -126,4 +126,5 @@ v_configptr: equ 0x00003FF3
 
 ; flags: bit 0 - IP set (either static or via DHCP)
 v_ethflags: equ 0x3FF5
+v_nmipage: equ 0x3FF6
 

--- a/rom/reset.asm
+++ b/rom/reset.asm
@@ -97,6 +97,10 @@ J_reset:
 	ld a, v_fd1hwsock % 256
 	ld (v_lastpolled), a
 
+	; Utility ROM is the default page for handing nmi vector
+	ld a, 0x02
+	ld (v_nmipage), a
+
 	; Set an initial local port number for connect()
 	call F_rand16
 	set 6, h		; make sure we start with a highish number

--- a/rom/trapdispatch.asm
+++ b/rom/trapdispatch.asm
@@ -51,6 +51,7 @@ do_callbas:
 .globl do_rst8
 do_rst8:
 	ld (v_hlsave), hl	; save hl without disturbing stack
+	ld (v_desave), de	; save de
 	pop hl			; get stack value - entry code
 	push hl
 	push af
@@ -80,5 +81,6 @@ do_rst8:
 	pop af			; restore af
 	pop hl			; fix stack
 	ld hl, (v_hlsave)	; restore hl
+	ld de, (v_desave)	; restore de
 	ret			; go back to the calling routine.
 

--- a/rom/zeropage.asm
+++ b/rom/zeropage.asm
@@ -97,6 +97,12 @@ NMI2:
 	in a, (c)
 	and MASK_PROGTRAP_EN
 	jr z, .nmimenu0		; not enabled
+	ld a, (v_trapcomefrom)
+	ld b, a
+	ld a, (v_trapcomefrom+1)
+	or b
+	jr z, NMI3          ; v_trapcomefrom is zero, accept any address
+
 	ld a, (v_trapcomefrom)	; get comefrom address LSB
 	cp (hl)			; equal to low order?
 	jr nz, .nmimenu0		; no
@@ -105,6 +111,7 @@ NMI2:
 	cp (hl)			; equal to high order?
 	jr nz, .nmimenu0		; no
 
+NMI3:
 	; Set up the environment ready to handle the trap.
 	ld a, (v_trappage)	; get the page to page in
 	and a			; if it's zero though, ignore it.

--- a/rom/zeropage.asm
+++ b/rom/zeropage.asm
@@ -113,7 +113,7 @@ NMI2:
 	jp (hl)			; jump to it
 	
 .nmimenu0:
-	ld a, 0x02		; Utility ROM
+	ld a, (v_nmipage)   ; Utility ROM
 	call F_setpageB
 	ld hl, (NMI_VECTOR)	; Test NMI_VECTOR
 	ld a, 0xFF


### PR DESCRIPTION
Currently, there is no way to run custom code on the NMI button. Every module has `NMI_VECTOR` variable, but it currently ignored for every module except the Utility ROM (page `0x02`).

This change creates a new variable `v_nmipage`, located at `0x3FF6`, which denotes a page lo load the NMI_VECTOR from and execute the NMI on. By default, it is equal `0x02` but when changed, it would test and load an appropriate page instead, and execute custom NMI code.

Armed with that, any module can do (C example):
```
*(uint8_t*)0x3FF6 = *(uint8_t*)0x3F07;
```
And take control over NMI handling.