### PR TITLE
Only printf on DEBUG enabled in tnfs_handle_tcpmsg

### DIFF
--- a/tnfs/tnfsd/datagram.c
+++ b/tnfs/tnfsd/datagram.c
@@ -279,7 +279,10 @@ void tnfs_handle_tcpmsg(int cli_fd)
 	int sz;
 
 	sz = read(cli_fd, buf, sizeof(buf));
-	printf("DEBUG: rx of tcpmsg: %d bytes: %s\n", sz, buf);
+#ifdef DEBUG
+  printf("DEBUG: rx of tcpmsg: %d bytes: %s\n", sz, buf);
+#endif
+
 }
 
 void tnfs_decode(struct sockaddr_in *cliaddr, int rxbytes, unsigned char *rxbuf)


### PR DESCRIPTION
This unguarded printf filled my logs, it should only be enabled when running a DEBUG build