### PR TITLE
Firmware support for issue 3 boards

### DIFF
--- a/include/sysvars.inc
+++ b/include/sysvars.inc
@@ -127,3 +127,4 @@ v_configptr: equ 0x00003FF3
 ; flags: bit 0 - IP set (either static or via DHCP)
 v_ethflags: equ 0x3FF5
 
+v_flashid: equ 0x3FF6

--- a/syslib/flashwrite.asm
+++ b/syslib/flashwrite.asm
@@ -32,12 +32,8 @@
 ; Attempt to identify the flash ROM IC present on the spectranet
 ; sets a system variable in SRAM containing the device ID which should be
 ; 0x20 for an Am29F010, or 0xB5 for an SST39SF010
-; Only probe chip when sysvar is zero.
 .globl F_FlashIdentify
 F_FlashIdentify:
-	ld a,(v_flashid)
-	cp 0
-	jr nz, .skipIdentify ; skip identification if sysvar is non zero
 	push bc
 	ld bc, PAGEB
 	ld a,5
@@ -64,7 +60,6 @@ F_FlashIdentify:
     ld a,(v_pgb)
     out (c),a	; restore page B
 	pop bc
-.skipIdentify:
 	ret
 
 ;---------------------------------------------------------------------------

--- a/syslib/flashwrite.asm
+++ b/syslib/flashwrite.asm
@@ -39,15 +39,15 @@ F_FlashIdentify:
 	ld a,5
 	out (c),a	; flash A12-A15 bits to 5
 	ld a, 0xAA	; unlock code 1
-	ld (0x555), a	; unlock addr 1
+	ld (0x2555), a	; unlock addr 1
 	ld a,2
 	out (c),a	; flash A12-A15 bits to 2
 	ld a, 0x55	; unlock code 2
-	ld (0xAAA), a	; unlock addr 2
+	ld (0x2AAA), a	; unlock addr 2
     ld a,5
 	out (c),a	; flash A12-A15 bits to 2
     ld a, 0x90	; ID code
-	ld (0x555), a	; ID
+	ld (0x2555), a	; ID
 	ld a,0
 	out (c),a	; flash A12-A15 bits to 0
     ld a, (0x0001)	; read device ID
@@ -103,21 +103,21 @@ F_doErase:
 	ld a,5
 	out (c),a	; flash A12-A15 bits to 5
 	ld a, 0xAA	; unlock code 1
-	ld (0x555), a	; unlock addr 1
+	ld (0x2555), a	; unlock addr 1
 	ld a,2
 	out (c),a	; flash A12-A15 bits to 2
 	ld a, 0x55	; unlock code 2
-	ld (0xAAA), a	; unlock addr 2
+	ld (0x2AAA), a	; unlock addr 2
 	ld a,5
 	out (c),a	; flash A12-A15 bits to 5
 	ld a, 0x80	; erase cmd 1
-	ld (0x555), a	; erase cmd addr 1
+	ld (0x2555), a	; erase cmd addr 1
 	ld a, 0xAA	; erase cmd 2
-	ld (0x555), a	; erase cmd addr 2
+	ld (0x2555), a	; erase cmd addr 2
 	ld a,2
 	out (c),a	; flash A12-A15 bits to 2
 	ld a, 0x55	; erase cmd 3
-	ld (0xAAA), a	; erase cmd addr 3
+	ld (0x2AAA), a	; erase cmd addr 3
 	ld a,l
 	out (c),a	; flash A12-A15 bits to 4k page number
 	ld (v_pgb), a ; update pageB sysvar
@@ -181,17 +181,17 @@ F_FlashWriteByte:
     ld a, 5
     out (c),a	; flash A12-A15 bits to 5
 	ld a, 0xAA	; unlock 1
-	ld (0x555), a	; unlock address 1
+	ld (0x2555), a	; unlock address 1
     
     ld a, 2
     out (c),a	; flash A12-A15 bits to 2
 	ld a, 0x55	; unlock 2
-	ld (0xAAA), a	; unlock address 2
+	ld (0x2AAA), a	; unlock address 2
     
     ld a, 5
     out (c),a	; flash A12-A15 bits to 5
 	ld a, 0xA0	; Program
-	ld (0x555), a	; Program address
+	ld (0x2555), a	; Program address
     
     ld a, (v_pgb)
     out (c),a	; restore page B

--- a/syslib/flashwrite.asm
+++ b/syslib/flashwrite.asm
@@ -48,10 +48,12 @@ F_FlashIdentify:
 	out (c),a	; flash A12-A15 bits to 2
 	ld a, 0x55	; unlock code 2
 	ld (0xAAA), a	; unlock addr 2
+    ld a,5
+	out (c),a	; flash A12-A15 bits to 2
+    ld a, 0x90	; ID code
+	ld (0x555), a	; ID
 	ld a,0
 	out (c),a	; flash A12-A15 bits to 0
-	ld a, 0x90	; ID code
-	ld (0x555), a	; ID
     ld a, (0x0001)	; read device ID
     ld (v_flashid),a	; store device ID in SRAM
     ld (0x401F),a ; DEBUG

--- a/syslib/flashwrite.asm
+++ b/syslib/flashwrite.asm
@@ -52,9 +52,9 @@ F_FlashIdentify:
 	out (c),a	; flash A12-A15 bits to 0
     ld a, (0x0001)	; read device ID
     ld (v_flashid),a	; store device ID in SRAM
-    ld (0x401F),a ; DEBUG
-    ld a,0x55 ; DEBUG
-    ld (0x411F),a ; DEBUG
+    ;ld (0x401F),a ; DEBUG
+    ;ld a,0x55 ; DEBUG
+    ;ld (0x411F),a ; DEBUG
     ld a, 0xF0	; reset code
 	ld (0x0000),a	; reset flash
     ld a,(v_pgb)

--- a/syslib/flashwrite.asm
+++ b/syslib/flashwrite.asm
@@ -24,36 +24,103 @@
 ; Note that these routines can't actually be run from flash! They should
 ; be assembled to RAM instead.
 .include	"sysdefs.inc"
+.include	"sysvars.inc"
 .text
 
 ;---------------------------------------------------------------------------
+; F_FlashIdentify
+; Attempt to identify the flash ROM IC present on the spectranet
+; sets a system variable in SRAM containing the device ID which should be
+; 0x20 for an Am29F010, or 0xB5 for an SST39SF010
+; Only probe chip when sysvar is zero.
+.globl F_FlashIdentify
+F_FlashIdentify:
+	ld a,(v_flashid)
+	cp 0
+	jr nz, .skipIdentify ; skip identification if sysvar is non zero
+	push bc
+	ld bc, PAGEB
+	ld a,5
+	out (c),a	; flash A12-A15 bits to 5
+	ld a, 0xAA	; unlock code 1
+	ld (0x555), a	; unlock addr 1
+	ld a,2
+	out (c),a	; flash A12-A15 bits to 2
+	ld a, 0x55	; unlock code 2
+	ld (0xAAA), a	; unlock addr 2
+	ld a,0
+	out (c),a	; flash A12-A15 bits to 0
+	ld a, 0x90	; ID code
+	ld (0x555), a	; ID
+    ld a, (0x0001)	; read device ID
+    ld (v_flashid),a	; store device ID in SRAM
+    ld (0x401F),a ; DEBUG
+    ld a,0x55 ; DEBUG
+    ld (0x411F),a ; DEBUG
+    ld a, 0xF0	; reset code
+	ld (0x0000),a	; reset flash
+    ld a,(v_pgb)
+    out (c),a	; restore page B
+	pop bc
+.skipIdentify:
+	ret
+
+;---------------------------------------------------------------------------
 ; F_FlashEraseSector
-; Simple flash writer for the Am29F010 (and probably any 1 megabit flash
-; with 16kbyte sectors)
+; Simple flash writer for the Am29F010 and SST39SF010
+; Erases one 16k sector or four 4k sectors based on detected device
 ;
 ; Parameters: A = page to erase (based on 4k Spectranet pages, but
 ; erases a 16k sector)
 ; Carry flag is set if an error occurs.
 .globl F_FlashEraseSector
-F_FlashEraseSector: 
+F_FlashEraseSector:
+	; preserve page to start the erase from in C
+	ld c,a
 
-	; Page in the appropriate sector first 4k into page area B.
-	; Page to start the erase from is in A.
-	call F_setpageB	; page into page area B
+	call F_FlashIdentify
 
+	ld a,(v_flashid)	; load flash type
+	ld b,4 ; erase four 4k sectors
+	cp 0xB5	; SST39SF010A
+    ; this could potentially give a false positive if a ROM contained OR L in the second byte
+    ; a more robust check would be to also test the manufacturer ID is 0xBF (SST)
+	jr z, .eraseLoop
+	ld b,1 ; erase one 16k sector
+.eraseLoop:
+	call F_doErase
+    inc c
+	djnz .eraseLoop
+	ret
+
+F_doErase:
+	push bc
+	ld l,c
+	ld bc, PAGEB
+	ld a,5
+	out (c),a	; flash A12-A15 bits to 5
 	ld a, 0xAA	; unlock code 1
 	ld (0x555), a	; unlock addr 1
+	ld a,2
+	out (c),a	; flash A12-A15 bits to 2
 	ld a, 0x55	; unlock code 2
-	ld (0x2AA), a	; unlock addr 2
+	ld (0xAAA), a	; unlock addr 2
+	ld a,5
+	out (c),a	; flash A12-A15 bits to 5
 	ld a, 0x80	; erase cmd 1
 	ld (0x555), a	; erase cmd addr 1
 	ld a, 0xAA	; erase cmd 2
 	ld (0x555), a	; erase cmd addr 2
+	ld a,2
+	out (c),a	; flash A12-A15 bits to 2
 	ld a, 0x55	; erase cmd 3
-	ld (0x2AA), a	; erase cmd addr 3
+	ld (0xAAA), a	; erase cmd addr 3
+	ld a,l
+	out (c),a	; flash A12-A15 bits to 4k page number
+	ld (v_pgb), a ; update pageB sysvar
 	ld a, 0x30	; erase cmd 4
 	ld (0x2000), a	; erase sector address
-
+	pop bc
 	ld hl, 0x2000
 .wait1: 
 	bit 7, (hl)	; test DQ7 - should be 1 when complete
@@ -102,22 +169,37 @@ F_FlashWriteBlock:
 ; it, and the address should be in that address space.
 .globl F_FlashWriteByte
 F_FlashWriteByte: 
+	push hl
 	push bc
-	ld c, a		; save A
-
+	ld l, a		; save A
+    
+	ld bc, PAGEB
+    
+    ld a, 5
+    out (c),a	; flash A12-A15 bits to 5
 	ld a, 0xAA	; unlock 1
 	ld (0x555), a	; unlock address 1
+    
+    ld a, 2
+    out (c),a	; flash A12-A15 bits to 2
 	ld a, 0x55	; unlock 2
-	ld (0x2AA), a	; unlock address 2
+	ld (0xAAA), a	; unlock address 2
+    
+    ld a, 5
+    out (c),a	; flash A12-A15 bits to 5
 	ld a, 0xA0	; Program
 	ld (0x555), a	; Program address
-	ld a, c		; retrieve A
+    
+    ld a, (v_pgb)
+    out (c),a	; restore page B
+    
+	ld a, l		; retrieve A
 	ld (de), a	; program it
 
 .wait3: 
 	ld a, (de)	; read programmed address
 	ld b, a		; save status
-	xor c		
+	xor l		
 	bit 7, a	; If bit 7 = 0 then bit 7 = data	
 	jr z,  .byteComplete3
 
@@ -125,17 +207,19 @@ F_FlashWriteByte:
 	jr z,  .wait3
 
 	ld a, (de)	; read programmed address
-	xor c		
+	xor l		
 	bit 7, a	; Does DQ7 = programmed data? 0 if true
 	jr nz,  .borked3
 
-.byteComplete3: 
+.byteComplete3:
 	pop bc
+	pop hl
 	or 0		; clear carry flag
 	ret
 
 .borked3: 
 	pop bc
+	pop hl
 	scf		; error = set carry flag
 	ret
 


### PR DESCRIPTION
Simple workaround to support 4kB sector Flash chips.
Always erases four sectors to emulate a 16kB erase sector chip, which then most likely get written back, so a proper rewrite would be better to make everything more efficient in future.