### PR TITLE
libspdos: a library for working with file systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.o
+*_np.asm
+*_p.asm
+*.lib
+.idea
+*.module
+*.bin
+*.map
+*.tap
+*.tzx
+*.xinc
+*.a
+/utils/bin2tape
+/utils/configserv

--- a/z88dk/Makefile
+++ b/z88dk/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = libspectranet socklib libhttp
+SUBDIRS = libspectranet socklib libhttp libspdos
 INSTALLDIRS = $(SUBDIRS:%=install-%)
 
 .PHONY:	subdirs $(SUBDIRS)

--- a/z88dk/libspdos/Makefile
+++ b/z88dk/libspdos/Makefile
@@ -1,0 +1,27 @@
+# Makefile to build the Spectranet VFS DOS library (libspdos)
+# Expects Spectranet to be paged in
+
+LIBNAME = libspdos
+COBJS = open.o close.o read.o write.o readbyte.o writebyte.o lseek.o \
+	mkdir.o rmdir.o chdir.o getcwd.o \
+	rename.o remove.o unlink.o \
+	opendir.o readdir.o closedir.o \
+	mount.o umount.o stat.o
+CFLAGS = +zx -vn -I./include -I/usr/local/z88dk/share/z88dk/include -O2
+
+# Pattern rule to compile .c to .o
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+all:	$(COBJS)
+	$(LIBLINKER) $(LIBLDFLAGS) -x$(LIBNAME) $(COBJS)
+
+$(LIBNAME).lib: $(COBJS)
+	$(LIBLINKER) $(LIBLDFLAGS) -x$(LIBNAME) $(COBJS)
+
+install: $(LIBNAME).lib
+	$(CP) *.lib $(ZCCCFG)/../clibs
+	$(CP) -r ./include $(ZCCCFG)/../../
+
+include ../make.inc
+

--- a/z88dk/libspdos/chdir.c
+++ b/z88dk/libspdos/chdir.c
@@ -1,0 +1,27 @@
+#include <fcntl.h>
+
+int chdir(char *name) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl
+    push    hl
+    push    bc
+    
+    push    ix
+    ; VFS CHDIR: HL = directory name
+    call    CHDIR
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/close.c
+++ b/z88dk/libspdos/close.c
@@ -1,0 +1,27 @@
+#include <fcntl.h>
+
+int close(int handle) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc      ; return address
+    pop     hl      ; handle
+    push    hl
+    push    bc
+    
+    push    ix
+    ld      a,l     ; handle in A
+    call    VCLOSE
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0    ; success
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/closedir.c
+++ b/z88dk/libspdos/closedir.c
@@ -1,0 +1,28 @@
+#include <fcntl.h>
+
+int closedir(int dirhandle) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl      ; dirhandle
+    push    hl
+    push    bc
+    
+    push    ix
+    ld      a,l     ; directory handle in A
+    ; VFS CLOSEDIR: A = directory handle
+    call    CLOSEDIR
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/getcwd.c
+++ b/z88dk/libspdos/getcwd.c
@@ -1,0 +1,32 @@
+#include <fcntl.h>
+
+char *getcwd(char *buf, size_t buflen) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     de      ; buflen (ignored)
+    pop     hl      ; buf
+    push    hl
+    push    de
+    push    bc
+    
+    push    hl      ; save buf for return value
+    push    ix
+    ; VFS GETCWD: DE = pointer to buffer
+    ex      de,hl   ; DE = buf
+    call    GETCWD
+    pop     ix
+    pop     hl      ; return buf pointer
+    
+    jr      c,error
+    ; Return buf pointer in HL
+    ret
+    
+error:
+    ld      hl,0    ; return NULL on error
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/include/spdos.h
+++ b/z88dk/libspdos/include/spdos.h
@@ -1,0 +1,90 @@
+#ifndef SPDOS_H
+#define SPDOS_H
+
+#include <fcntl.h>
+#include <sys/types.h>
+
+/* DOS-compatible filesystem functions forwarding to Spectranet VFS */
+
+/* Undefine system macros that conflict with our function declarations */
+#ifdef mkdir
+#undef mkdir
+#endif
+#ifdef rmdir
+#undef rmdir
+#endif
+
+/* File operations */
+int open(const char *name, int flags, mode_t mode);
+int close(int handle);
+ssize_t read(int handle, void *buf, size_t len);
+ssize_t write(int handle, void *buf, size_t len);
+int readbyte(int fd);
+int writebyte(int handle, int c);
+long lseek(int fd, long posn, int whence);
+
+/* Directory operations */
+int mkdir(char *name);
+int rmdir(char *name);
+int chdir(char *name);
+char *getcwd(char *buf, size_t buflen);
+
+/* File management */
+int rename(const char *s, const char *d);
+int remove(char *name);
+int unlink(char *name);
+
+/* Directory reading */
+int opendir(char *name);
+int readdir(int dirhandle, void *buf);
+int closedir(int dirhandle);
+
+/* File status */
+/* File mode constants (Spectranet VFS) */
+#ifndef S_IFDIR
+#define S_IFDIR 0x4000
+#endif
+#ifndef S_IFREG
+#define S_IFREG 0x8000
+#endif
+
+/* Mount operations (Spectranet-specific) */
+/**
+ * Mount a filesystem at the specified mount point.
+ * Note: if the mount point is already in use, the mount will fail.
+ * To use a different mount point, you must first unmount the filesystem
+ * using umount().
+ * 
+ * @param mount_point Mount point number (0-3)
+ * @param password Password string (can be NULL for anonymous access)
+ * @param user_id User ID string (can be NULL for anonymous access)
+ * @param path Mount source path (e.g., "/home/tnfs" or "ram")
+ * @param hostname Hostname or server address (e.g., "remote.domain" or NULL)
+ * @param protocol Protocol name (e.g., "tnfs", "xfs", "https")
+ * 
+ * @return 0 on success, -1 on error
+ * 
+ * @example
+ * // Mount TNFS filesystem
+ * mount(0, NULL, NULL, "/home/tnfs", "remote.domain", "tnfs");
+ * 
+ * // Mount XFS RAM filesystem
+ * mount(0, NULL, NULL, "ram", NULL, "xfs");
+ * 
+ * // Mount with authentication
+ * mount(0, "mypassword", "myuser", "/home/tnfs", "remote.domain", "tnfs");
+ */
+int mount(int mount_point, char* password, char* user_id, char* path, char* hostname, char *protocol);
+int umount(int mount_point);
+
+/* File status */
+int stat(const char *path, struct stat *buf);
+/* Check if a path is a directory */
+int isdir(const char *path);
+
+
+int setmountpoint(int mount_point);
+int getmountpoint(void);
+
+#endif /* SPDOS_H */
+

--- a/z88dk/libspdos/lseek.c
+++ b/z88dk/libspdos/lseek.c
@@ -1,0 +1,47 @@
+#include <fcntl.h>
+
+long lseek(int fd, long posn, int whence) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    push    ix
+    ld      ix,4
+    add     ix,sp
+    
+    ; Stack: [ix][ret][fd][posn_low][posn_high][whence]
+    ; Parameters: fd at SP+4, posn_low at SP+6, posn_high at SP+8, whence at SP+10
+    
+    ; Get file descriptor (16-bit, but we only need low byte for VFS)
+    ld      a,(ix+0)
+    
+    ; Get position (32-bit signed): DEHL
+    ; posn is stored as: low word (LSB first), high word (LSB first)
+    ld      l,(ix+2)    ; posn_low LSB
+    ld      h,(ix+3)    ; posn_low MSB
+    ld      e,(ix+4)    ; posn_high LSB
+    ld      d,(ix+5)    ; posn_high MSB
+    
+    ; Get whence (16-bit, but we only need low byte for VFS)
+    ld      c,(ix+6)
+    
+    ; VFS LSEEK: A=fd, C=whence, DEHL=position
+    call    LSEEK
+    
+    jr      c,error
+    ; Return position in DEHL, but C expects long in HLDE
+    ; Actually, return value is typically the new position
+    ; For now, return 0 on success, -1 on error
+    pop     ix
+    ld      hl,0
+    ld      de,0
+    ret
+    
+error:
+    pop     ix
+    ld      hl,-1
+    ld      de,0xFFFF
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/mkdir.c
+++ b/z88dk/libspdos/mkdir.c
@@ -1,0 +1,27 @@
+#include <fcntl.h>
+
+int mkdir(char *name) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl
+    push    hl
+    push    bc
+    
+    push    ix
+    ; VFS MKDIR: HL = directory name
+    call    MKDIR
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/mount.c
+++ b/z88dk/libspdos/mount.c
@@ -1,0 +1,92 @@
+#include <fcntl.h>
+
+int mount(int mount_point, char* password, char* user_id, char* path, char* hostname, char *protocol) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    push    ix
+    ld      ix,4
+    add     ix,sp
+    
+    ; Parameters are pushed right-to-left, so rightmost is at lowest address:
+    ; protocol at (ix+0) - rightmost parameter, pushed first
+    ; hostname at (ix+2)
+    ; path at (ix+4)
+    ; user_id at (ix+6)
+    ; password at (ix+8)
+    ; mount_point at (ix+10) - leftmost parameter, pushed last
+    
+    ; Get mount_point (leftmost parameter, at highest offset)
+    ld      a,(ix+10)
+    
+    ; IX already points to protocol (ix+0), which matches the structure layout:
+    ; byte 0,1: protocol pointer (ix+0)
+    ; byte 2,3: hostname pointer (ix+2)
+    ; byte 4,5: path pointer (ix+4)
+    ; byte 6,7: user_id pointer (ix+6)
+    ; byte 8,9: password pointer (ix+8)
+    
+    ; Call VFS MOUNT: IX=structure, A=mount_point
+    call    MOUNT
+    
+    ; Check return flags
+    ; On success: Z reset, C reset
+    ; Protocol not recognized: Z set, C reset
+    ; Mount failed: C set
+    jr      c,error
+    jr      z,error
+    
+    pop     ix
+    ld      hl,0
+    ret
+    
+error:
+    pop     ix
+    ld      hl,-1
+    ret
+#endasm
+}
+
+int setmountpoint(int mount_point) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl      ; mount_point
+    push    hl
+    push    bc
+    
+    push    ix
+    ; SETMOUNTPOINT: A = mount_point (0 to 3)
+    ld      a,l
+    call    SETMOUNTPOINT
+    pop     ix
+    
+    ; Returns with carry set on error (mount_point > 3)
+    jr      c,setmount_error
+    ld      hl,0
+    ret
+    
+setmount_error:
+    ld      hl,-1
+    ret
+#endasm
+}
+
+int getmountpoint(void) __naked
+{
+#asm
+    push    ix
+    ; Read from system variable v_vfs_curmount at 0x3F6F
+    ld      hl,0x3F6F
+    ld      a,(hl)
+    pop     ix
+    
+    ; Return mount point (0-3) in HL
+    ld      h,0
+    ld      l,a
+    ret
+#endasm
+}

--- a/z88dk/libspdos/open.c
+++ b/z88dk/libspdos/open.c
@@ -1,0 +1,42 @@
+#include <fcntl.h>
+
+int open(char *name, int flags, mode_t mode) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    push    ix
+    ld      ix,4
+    add     ix,sp
+    
+    ; Stack: [ix][ret][name][flags][mode]
+    ; Parameters: name at SP+4, flags at SP+6, mode at SP+8
+    
+    ; Get mode
+    ld      c,(ix+0)
+    ld      b,(ix+1)
+    
+    ; Get flags
+    ld      e,(ix+2)
+    ld      d,(ix+3)
+
+    ; Get filename pointer
+    ld      l,(ix+4)
+    ld      h,(ix+5)
+    
+    ; VFS OPEN: HL=filename, DE=flags, BC=mode
+    call    OPEN
+    
+    jr      c,error
+    ld      h,0
+    ld      l,a      ; return handle
+    jr      end
+    
+error:
+    ld      hl,-1
+    
+end:
+    pop     ix
+    ret
+#endasm
+}

--- a/z88dk/libspdos/opendir.c
+++ b/z88dk/libspdos/opendir.c
@@ -1,0 +1,28 @@
+#include <fcntl.h>
+
+int opendir(char *name) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl
+    push    hl
+    push    bc
+    
+    push    ix
+    ; VFS OPENDIR: HL = directory name
+    call    OPENDIR
+    pop     ix
+    
+    jr      c,error
+    ld      h,0
+    ld      l,a     ; return directory handle
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/read.c
+++ b/z88dk/libspdos/read.c
@@ -1,0 +1,46 @@
+#include <fcntl.h>
+
+ssize_t read(int handle, void *buf, size_t len) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    push    ix
+    ld      ix,4
+    add     ix,sp
+    
+    ; Get len
+    ld      c,(ix+0)
+    ld      b,(ix+1)
+    
+    ; Get buf
+    ld      l,(ix+2)
+    ld      h,(ix+3)
+    ex      de,hl   ; DE = buf (for VFS)
+    
+    ; Get handle
+    ld      a,(ix+4)
+    
+    ; VFS READ: A=handle, DE=buf, BC=len
+    call    READ
+    ; BC contains bytes read on success or EOF
+    ; Check carry flag - but EOF may set carry even though bytes were read
+    jr      nc,success
+    ; Carry is set - check if BC > 0 (EOF with data) or BC == 0 (error)
+    ld      a,b
+    or      c       ; Check if BC is zero
+    jr      z,error ; BC == 0 means error
+    ; BC > 0 means EOF with data - treat as success
+success:
+    pop     ix
+    ld      h,b
+    ld      l,c
+    ret
+    
+error:
+    pop     ix
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/readbyte.c
+++ b/z88dk/libspdos/readbyte.c
@@ -1,0 +1,42 @@
+#include <fcntl.h>
+
+int readbyte(int fd) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc      ; return address
+    pop     af      ; fd
+    push    af
+    push    bc
+
+    push    ix
+    push    hl      ; Reserve space on stack for byte (fd value, will be overwritten)
+
+    ld      hl,0
+    add     hl,sp   ; HL points to buffer on stack
+    ex      de,hl   ; DE = buffer
+    ld      bc,1    ; Read 1 byte
+
+    call    READ
+
+    pop     hl      ; Get byte from stack (byte is in L)
+    pop     ix      ; Restore IX
+    
+    ; check if BC > 0 (EOF with data) or BC == 0 (error)
+    ld      a,b
+    or      c       ; Check if BC is zero
+    jr      z, error
+    
+    ; Byte value is in L register (from pop hl)
+    ld      h,0
+    and     a       ; Clear carry flag
+    ret
+    
+error:
+    ld      hl,-1
+    scf     ; Set carry flag for error
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/readdir.c
+++ b/z88dk/libspdos/readdir.c
@@ -1,0 +1,31 @@
+#include <fcntl.h>
+
+int readdir(int dirhandle, void *buf) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     de      ; buf
+    pop     hl      ; dirhandle
+    push    hl
+    push    de
+    push    bc
+    
+    push    ix
+    ld      a,l     ; directory handle in A
+    ; VFS READDIR: A = directory handle, DE = buffer
+    ; DE is already set up correctly
+    call    READDIR
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0    ; success
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/remove.c
+++ b/z88dk/libspdos/remove.c
@@ -1,0 +1,27 @@
+#include <fcntl.h>
+
+int remove(char *name) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl
+    push    hl
+    push    bc
+    
+    push    ix
+    ; VFS UNLINK: HL = filename
+    call    UNLINK
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/rename.c
+++ b/z88dk/libspdos/rename.c
@@ -1,0 +1,29 @@
+#include <fcntl.h>
+
+int rename(const char *s, const char *d) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     de      ; destination
+    pop     hl      ; source
+    push    hl
+    push    de
+    push    bc
+    
+    push    ix
+    ; VFS RENAME: HL = source path, DE = destination path
+    call    RENAME
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/rmdir.c
+++ b/z88dk/libspdos/rmdir.c
@@ -1,0 +1,27 @@
+#include <fcntl.h>
+
+int rmdir(char *name) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl
+    push    hl
+    push    bc
+    
+    push    ix
+    ; VFS RMDIR: HL = directory name
+    call    RMDIR
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/spectranet.asm
+++ b/z88dk/libspdos/spectranet.asm
@@ -1,0 +1,9 @@
+; Wrapper for spectranet.inc with include guard
+; This prevents duplicate definitions when spectranet.inc is included multiple times
+
+IFNDEF SPECTRANET_INC_INCLUDED
+DEFINE SPECTRANET_INC_INCLUDED
+
+include "../../include/spectranet.inc"
+
+ENDIF ; SPECTRANET_INC_INCLUDED

--- a/z88dk/libspdos/stat.c
+++ b/z88dk/libspdos/stat.c
@@ -1,0 +1,63 @@
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "spdos.h"
+
+int stat(const char* path, struct stat* buf) __naked
+{
+#asm
+    include "../../include/spectranet.inc"
+    
+    push    ix
+    ld      ix,4
+    add     ix,sp
+    
+    ; Stack: [saved IX][ret][buf][path]
+    ; Parameters: buf at (ix+0), path at (ix+2)
+    ; Note: Parameters are pushed right-to-left, so path (rightmost) is pushed first,
+    ;       then buf (leftmost) is pushed second, making buf at lower offset
+    
+    ; Get buf pointer (first parameter)
+    ld      e,(ix+0)
+    ld      d,(ix+1)
+    
+    ; Get path pointer (second parameter)
+    ld      l,(ix+2)
+    ld      h,(ix+3)
+    
+    ; STAT: HL = path, DE = buffer for stat info
+    ; Returns: C set on error, Z set on error, C reset and Z reset on success
+    call    STAT
+    
+    jr      c,stat_error
+    jr      z,stat_error
+    
+    ; Success - stat info is now in buffer pointed to by DE
+    ; The caller can access it via the buf pointer
+    ld      hl,0
+    jr      stat_end
+    
+stat_error:
+    ld      hl,-1
+    
+stat_end:
+    pop     ix
+    ret
+#endasm
+}
+
+// Helper function to check if a path is a directory
+int isdir(const char* path)
+{
+    // Allocate buffer for stat info (256 bytes as per VFS spec)
+    static unsigned char statbuf[256];
+    struct stat* st = (struct stat*)statbuf;
+    
+    if (stat(path, st) < 0) {
+        return 0;
+    }
+    
+    // Check if directory bit is set in mode
+    // STAT_MODE is at offset 0, little-endian 16-bit value
+    unsigned short mode = *(unsigned short*)statbuf;
+    return (mode & S_IFDIR) != 0;
+}

--- a/z88dk/libspdos/umount.c
+++ b/z88dk/libspdos/umount.c
@@ -1,0 +1,28 @@
+#include <fcntl.h>
+
+int umount(int mount_point) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl      ; mount_point
+    push    hl
+    push    bc
+    
+    push    ix
+    ; VFS UMOUNT: A = mount_point (0 to 3)
+    ld      a,l
+    call    UMOUNT
+    pop     ix
+    
+    ; UMOUNT returns with carry set on error
+    jr      c,error
+    ld      hl,0
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}

--- a/z88dk/libspdos/unlink.c
+++ b/z88dk/libspdos/unlink.c
@@ -1,0 +1,27 @@
+#include <fcntl.h>
+
+int unlink(char *name) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc
+    pop     hl
+    push    hl
+    push    bc
+    
+    push    ix
+    ; VFS UNLINK: HL = filename
+    call    UNLINK
+    pop     ix
+    
+    jr      c,error
+    ld      hl,0
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/write.c
+++ b/z88dk/libspdos/write.c
@@ -1,0 +1,40 @@
+#include <fcntl.h>
+
+ssize_t write(int handle, void *buf, size_t len) __naked
+{
+#asm
+    include "spectranet.asm"
+
+    push    ix
+    
+    ld      ix,4
+    add     ix,sp
+    
+    ; Get len
+    ld      c,(ix+0)
+    ld      b,(ix+1)
+    
+    ; Get buf
+    ld      l,(ix+2)
+    ld      h,(ix+3)
+
+    ; Get handle
+    ld      a,(ix+4)
+    
+    ; VFS WRITE: A=handle, HL=buf, BC=size
+    call    WRITE
+
+    pop     ix
+    
+    ; BC contains bytes written on success
+    jr      c,error
+    ld      h,b
+    ld      l,c
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+

--- a/z88dk/libspdos/writebyte.c
+++ b/z88dk/libspdos/writebyte.c
@@ -1,0 +1,35 @@
+#include <fcntl.h>
+
+int writebyte(int handle, int c) __naked
+{
+#asm
+    include "spectranet.asm"
+    
+    pop     bc      ; return address
+    pop     hl      ; c (byte to write)
+    pop     de      ; handle
+    push    de
+    push    hl
+    push    bc
+    
+    push    ix
+    ld      a,e     ; handle in A
+    ; Use stack for single byte buffer
+    ld      hl,2
+    add     hl,sp   ; HL points to c on stack
+    ld      bc,1    ; Write 1 byte
+    call    WRITE
+    pop     ix
+    
+    jr      c,error
+    ; BC contains bytes written (should be 1)
+    ld      h,b
+    ld      l,c     ; Return bytes written
+    ret
+    
+error:
+    ld      hl,-1
+    ret
+#endasm
+}
+


### PR DESCRIPTION
This change adds support for programs to work with files in a mounted environment. For example, if a program is loaded from within tnfs, such a program can access neighboring files and such, with functions like `open`, `read` etc, independent from the filesystem it operates under. The library is basically a wrapper around spectranet's virtual filesystem.

Example: https://github.com/spectranext/spectranext-sdk/blob/master/examples/spdos-file-list/main.c

The change is documented here: https://docs.spectranext.net/api/spdos
You can find the library precompiled here: https://github.com/spectranext/spectranext-sdk/tree/master/clibs 

Example program [Archive.zip](https://github.com/user-attachments/files/25219056/Archive.zip)

```
%umount 0
%mount 0, "tnfs.markround.com"
<insert tape>
LOAD ""
```

Observe
<img width="638" height="472" alt="image" src="https://github.com/user-attachments/assets/8c90fc3e-f5c0-4130-94a8-84860552245d" />

This is backport from [spectranext project](https://spectranext.net/) as I want the ROM and library suite to be ideally identical.
